### PR TITLE
Format implementations

### DIFF
--- a/core/src/main/scala/java/text/AttributedCharacterIterator.scala
+++ b/core/src/main/scala/java/text/AttributedCharacterIterator.scala
@@ -1,0 +1,42 @@
+package java.text
+
+trait AttributedCharacterIterator extends CharacterIterator {
+  def getRunStart(): Int
+
+  def getRunStart(attribute: AttributedCharacterIterator.Attribute): Int
+
+  def getRunStart(attributes: java.util.Set[_ <: AttributedCharacterIterator.Attribute]): Int
+
+  def getRunLimit(): Int
+
+  def getRunLimit(attribute: AttributedCharacterIterator.Attribute): Int
+
+  def getRunLimit(attributes: java.util.Set[_ <: AttributedCharacterIterator.Attribute]): Int
+
+  def getAttributes(): java.util.Map[AttributedCharacterIterator.Attribute, AnyRef]
+
+  def getAttribute(attribute: AttributedCharacterIterator.Attribute): AnyRef
+
+  def getAllAttributeKeys(): java.util.Set[AttributedCharacterIterator.Attribute]
+}
+
+object AttributedCharacterIterator {
+  class Attribute protected (private[this] val name: String) {
+    override final def equals(that: Any): Boolean = that match {
+      case t: Attribute => this.eq(t) // As per javadocs
+      case _ => false
+    }
+
+    override final def hashCode(): Int = name.hashCode
+
+    override def toString: String = s"java.text.AttributedCharacterIterator$$Attribute($getName)"
+
+    protected def getName(): String = name
+  }
+
+  object Attribute {
+    val LANGUAGE: Attribute = new Attribute("language")
+    val READING: Attribute = new Attribute("reading")
+    val INPUT_METHOD_SEGMENT: Attribute = new Attribute("input_method_segment")
+  }
+}

--- a/core/src/main/scala/java/text/CharacterIterator.scala
+++ b/core/src/main/scala/java/text/CharacterIterator.scala
@@ -1,0 +1,25 @@
+package java.text
+
+trait CharacterIterator extends Cloneable {
+  def first(): Char
+
+  def last(): Char
+
+  def current(): Char
+
+  def next(): Char
+
+  def previous(): Char
+
+  def setIndex(position: Int): Char
+
+  def getBeginIndex(): Int
+
+  def getEndIndex(): Int
+
+  def getIndex(): Int
+}
+
+object CharacterIterator {
+  val DONE: Char = '\uFFFF'
+}

--- a/core/src/main/scala/java/text/FieldPosition.scala
+++ b/core/src/main/scala/java/text/FieldPosition.scala
@@ -1,0 +1,41 @@
+package java.text
+
+class FieldPosition(private[this] val attribute: Format.Field, private[this] val fieldId: Int) {
+  private[this] var beginIndex: Int = 0
+  private[this] var endIndex: Int = 0
+
+  def this(attribute: Format.Field) = this(attribute, -1)
+
+  def this(fieldId: Int) = this(null, fieldId)
+
+  def getFieldAttribute(): Format.Field = attribute
+
+  def getField(): Int = fieldId
+
+  def getBeginIndex(): Int = beginIndex
+
+  def getEndIndex(): Int = endIndex
+
+  def setBeginIndex(bi: Int): Unit = beginIndex = bi
+
+  def setEndIndex(ei: Int): Unit = endIndex = ei
+
+  override def equals(other: Any): Boolean = other match {
+    case that: FieldPosition =>
+      getBeginIndex == that.getBeginIndex &&
+      getEndIndex == that.getEndIndex &&
+      getFieldAttribute == that.getFieldAttribute &&
+      getField == that.getField
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    // NOTE, the JVM doesn't use field attribute on hash but it uses on equal
+    val state = Seq(getBeginIndex, getEndIndex,/* getFieldAttribute,*/ getField)
+    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  }
+
+
+  override def toString =
+    s"java.text.FieldPosition[field=$getField,attribute=$getFieldAttribute,beginIndex=$getBeginIndex,endIndex=$getEndIndex]"
+}

--- a/core/src/main/scala/java/text/FieldPosition.scala
+++ b/core/src/main/scala/java/text/FieldPosition.scala
@@ -36,6 +36,6 @@ class FieldPosition(private[this] val attribute: Format.Field, private[this] val
   }
 
 
-  override def toString =
+  override def toString(): String =
     s"java.text.FieldPosition[field=$getField,attribute=$getFieldAttribute,beginIndex=$getBeginIndex,endIndex=$getEndIndex]"
 }

--- a/core/src/main/scala/java/text/Format.scala
+++ b/core/src/main/scala/java/text/Format.scala
@@ -1,0 +1,21 @@
+package java.text
+
+abstract class Format protected () extends Cloneable {
+  def format(obj: AnyRef): String = format(obj, new StringBuffer(), new FieldPosition(0)).toString()
+
+  def format(obj: AnyRef, toAppendTo: StringBuffer, pos: FieldPosition): StringBuffer
+
+  // TODO Implement
+  //def formatToCharacterIterator(obj: AnyRef): AttributedCharacterIterator
+
+  //def parseObject(source: String, pos: ParsePosition): AnyRef
+
+  //def parseObject(source: String): AnyRef
+}
+
+object Format {
+  class Field protected (private[this] val name: String) extends AttributedCharacterIterator.Attribute(name) {
+
+    override def toString = s"${getClass.getName}($name)"
+  }
+}

--- a/core/src/main/scala/java/text/Format.scala
+++ b/core/src/main/scala/java/text/Format.scala
@@ -1,21 +1,64 @@
 package java.text
 
+import AttributedCharacterIterator.Attribute
+
 abstract class Format protected () extends Cloneable {
   def format(obj: AnyRef): String = format(obj, new StringBuffer(), new FieldPosition(0)).toString()
 
   def format(obj: AnyRef, toAppendTo: StringBuffer, pos: FieldPosition): StringBuffer
 
-  // TODO Implement
-  //def formatToCharacterIterator(obj: AnyRef): AttributedCharacterIterator
+  def formatToCharacterIterator(obj: AnyRef): AttributedCharacterIterator =
+    new Format.EmptyAttributedCharacterIterator
 
-  //def parseObject(source: String, pos: ParsePosition): AnyRef
+  def parseObject(source: String, pos: ParsePosition): AnyRef
 
-  //def parseObject(source: String): AnyRef
+  def parseObject(source: String): AnyRef =
+    parseObject(source, new ParsePosition(0))
 }
 
 object Format {
+  private class EmptyAttributedCharacterIterator extends AttributedCharacterIterator {
+    override def getAttributes: java.util.Map[Attribute, AnyRef] =
+      new java.util.HashMap()
+
+    override def getAttribute(attribute: Attribute): AnyRef = null
+
+    override def getAllAttributeKeys: java.util.Set[Attribute] =
+      new java.util.TreeSet()
+
+    override def getRunLimit: Int = 0
+
+    override def getRunLimit(attribute: Attribute): Int = 0
+
+    override def getRunLimit(attributes: java.util.Set[_ <: Attribute]): Int = 0
+
+    override def getRunStart: Int = 0
+
+    override def getRunStart(attribute: Attribute): Int = 0
+
+    override def getRunStart(attributes: java.util.Set[_ <: Attribute]): Int = 0
+
+    override def next(): Char = 0
+
+    override def setIndex(position: Int): Char = 0
+
+    override def getIndex: Int = 0
+
+    override def last(): Char = 0
+
+    override def getBeginIndex: Int = 0
+
+    override def getEndIndex: Int = 0
+
+    override def current(): Char = 0
+
+    override def previous(): Char = 0
+
+    override def first(): Char = 0
+  }
+
   class Field protected (private[this] val name: String) extends AttributedCharacterIterator.Attribute(name) {
 
-    override def toString = s"${getClass.getName}($name)"
+    override def toString(): String = s"${getClass.getName}($name)"
   }
 }

--- a/core/src/main/scala/java/text/ParseException.scala
+++ b/core/src/main/scala/java/text/ParseException.scala
@@ -1,0 +1,7 @@
+package java.text
+
+class ParseException(private[this] val s: String, private[this] val errorOffset: Int)
+    extends Exception(s) {
+
+  def getErrorOffset(): Int = errorOffset
+}

--- a/core/src/main/scala/java/text/ParsePosition.scala
+++ b/core/src/main/scala/java/text/ParsePosition.scala
@@ -1,0 +1,28 @@
+package java.text
+
+class ParsePosition(private[this] var index: Int) {
+  private[this] var errorIndex: Int = -1
+
+  def getIndex(): Int = index
+
+  def setIndex(index: Int): Unit = this.index = index
+
+  def setErrorIndex(ei: Int): Unit = this.errorIndex = ei
+
+  def getErrorIndex(): Int = errorIndex
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ParsePosition =>
+      getErrorIndex == that.getErrorIndex &&
+      getIndex == that.getIndex
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    val state = Seq(getErrorIndex, getIndex)
+    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  }
+
+  override def toString =
+    s"java.text.ParsePosition[index=$getIndex,errorIndex=$getErrorIndex]"
+}

--- a/core/src/main/scala/java/text/ParsePosition.scala
+++ b/core/src/main/scala/java/text/ParsePosition.scala
@@ -23,6 +23,6 @@ class ParsePosition(private[this] var index: Int) {
     state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
   }
 
-  override def toString =
+  override def toString(): String =
     s"java.text.ParsePosition[index=$getIndex,errorIndex=$getErrorIndex]"
 }

--- a/testSuite/shared/src/test/scala/testsuite/javalib/text/AttributedCharacterIteratorTest.scala
+++ b/testSuite/shared/src/test/scala/testsuite/javalib/text/AttributedCharacterIteratorTest.scala
@@ -1,0 +1,19 @@
+package testsuite.javalib.text
+
+import java.text.AttributedCharacterIterator.Attribute
+
+import org.junit.Assert._
+import org.junit.Test
+
+class AttributedCharacterIteratorTest {
+  @Test def test_static_value_to_string(): Unit = {
+    assertEquals("java.text.AttributedCharacterIterator$Attribute(language)", Attribute.LANGUAGE.toString)
+    assertEquals("java.text.AttributedCharacterIterator$Attribute(reading)", Attribute.READING.toString)
+    assertEquals("java.text.AttributedCharacterIterator$Attribute(input_method_segment)", Attribute.INPUT_METHOD_SEGMENT.toString)
+  }
+
+  @Test def test_equals(): Unit = {
+    assertEquals(Attribute.LANGUAGE, Attribute.LANGUAGE)
+    assertFalse(Attribute.READING == Attribute.LANGUAGE)
+  }
+}

--- a/testSuite/shared/src/test/scala/testsuite/javalib/text/CharacterIteratorTest.scala
+++ b/testSuite/shared/src/test/scala/testsuite/javalib/text/CharacterIteratorTest.scala
@@ -1,0 +1,12 @@
+package testsuite.javalib.text
+
+import java.text.CharacterIterator
+
+import org.junit.Test
+import org.junit.Assert._
+
+class CharacterIteratorTest {
+  @Test def test_done(): Unit = {
+    assertEquals('\uFFFF', CharacterIterator.DONE)
+  }
+}

--- a/testSuite/shared/src/test/scala/testsuite/javalib/text/FieldPositionTest.scala
+++ b/testSuite/shared/src/test/scala/testsuite/javalib/text/FieldPositionTest.scala
@@ -1,0 +1,83 @@
+package testsuite.javalib.text
+
+import java.text.{FieldPosition, Format}
+
+import org.junit.Test
+import org.junit.Assert._
+
+class FieldPositionTest {
+  case class TestField(name: String) extends Format.Field(name)
+
+  @Test def test_constructors(): Unit = {
+    val field = TestField("abc")
+
+    val f1 = new FieldPosition(field, 1)
+    assertEquals(field, f1.getFieldAttribute())
+    assertEquals(1, f1.getField())
+    assertEquals(0, f1.getBeginIndex())
+    assertEquals(0, f1.getEndIndex())
+
+    val f2 = new FieldPosition(field)
+    assertEquals(field, f2.getFieldAttribute())
+    assertEquals(-1, f2.getField())
+    assertEquals(0, f2.getBeginIndex())
+    assertEquals(0, f2.getEndIndex())
+
+    val f3 = new FieldPosition(1)
+    assertNull(f3.getFieldAttribute())
+    assertEquals(1, f3.getField())
+    assertEquals(0, f3.getBeginIndex())
+    assertEquals(0, f3.getEndIndex())
+  }
+
+  @Test def test_begin_end_index(): Unit = {
+    val field = TestField("abc")
+
+    val f1 = new FieldPosition(field, 1)
+    f1.setBeginIndex(10)
+    assertEquals(10, f1.getBeginIndex())
+    f1.setBeginIndex(-10)
+    assertEquals(-10, f1.getBeginIndex())
+
+    f1.setEndIndex(10)
+    assertEquals(10, f1.getEndIndex())
+    f1.setEndIndex(-10)
+    assertEquals(-10, f1.getEndIndex())
+  }
+
+  @Test def test_equals_hash_code(): Unit = {
+    val field = TestField("abc")
+
+    val f1 = new FieldPosition(field, 1)
+    assertEquals(f1, f1)
+    assertEquals(f1.hashCode(), f1.hashCode())
+
+    val f2 = new FieldPosition(field, 1)
+    assertEquals(f1, f2)
+    assertEquals(f1.hashCode(), f2.hashCode())
+
+    val f3 = new FieldPosition(field)
+    assertFalse(f1.equals(f3))
+    assertFalse(f1.hashCode() == f3.hashCode())
+
+    val f4 = new FieldPosition(1)
+    assertFalse(f1.equals(f4))
+    // hashcode is broken on the JVM
+    assertEquals(f1.hashCode(), f4.hashCode())
+
+    f2.setBeginIndex(1)
+    assertFalse(f1.equals(f2))
+    assertFalse(f1.hashCode() == f2.hashCode())
+
+    val f5 = new FieldPosition(field, 1)
+    f5.setEndIndex(1)
+    assertFalse(f1.equals(f5))
+    assertFalse(f1.hashCode() == f5.hashCode())
+  }
+
+  @Test def test_to_string(): Unit = {
+    val field = TestField("abc")
+    val f1 = new FieldPosition(field, 1)
+    assertEquals("java.text.FieldPosition[field=1,attribute=testsuite.javalib.text.FieldPositionTest$TestField(abc),beginIndex=0,endIndex=0]", f1.toString)
+  }
+}

--- a/testSuite/shared/src/test/scala/testsuite/javalib/text/ParsePositionTest.scala
+++ b/testSuite/shared/src/test/scala/testsuite/javalib/text/ParsePositionTest.scala
@@ -1,0 +1,55 @@
+package testsuite.javalib.text
+
+import java.text.{FieldPosition, Format, ParsePosition}
+
+import org.junit.Assert._
+import org.junit.Test
+
+class ParsePositionTest {
+  @Test def test_constructors(): Unit = {
+    val p1 = new ParsePosition(1)
+    assertEquals(1, p1.getIndex())
+    assertEquals(-1, p1.getErrorIndex())
+  }
+
+  @Test def test_setters(): Unit = {
+    val p1 = new ParsePosition(1)
+    assertEquals(1, p1.getIndex())
+    assertEquals(-1, p1.getErrorIndex())
+
+    p1.setIndex(2)
+    p1.setErrorIndex(2)
+
+    assertEquals(2, p1.getIndex())
+    assertEquals(2, p1.getErrorIndex())
+  }
+
+  @Test def test_equals_hash_code(): Unit = {
+    val p1 = new ParsePosition(1)
+    assertEquals(p1, p1)
+    assertEquals(p1.hashCode(), p1.hashCode())
+
+    val p2 = new ParsePosition(1)
+    assertEquals(p1, p2)
+    assertEquals(p1.hashCode(), p2.hashCode())
+
+    val p3 = new ParsePosition(2)
+    assertFalse(p1.equals(p3))
+    assertFalse(p1.hashCode() == p3.hashCode())
+
+    p1.setIndex(4)
+    assertFalse(p1.equals(p2))
+    assertFalse(p1.hashCode() == p2.hashCode())
+
+    val p5 = new ParsePosition(1)
+    val p6 = new ParsePosition(1)
+    p5.setErrorIndex(1)
+    assertFalse(p5.equals(p6))
+    assertFalse(p5.hashCode() == p6.hashCode())
+  }
+
+  @Test def test_to_string(): Unit = {
+    val p1 = new ParsePosition(1)
+    assertEquals("java.text.ParsePosition[index=1,errorIndex=-1]", p1.toString)
+  }
+}


### PR DESCRIPTION
Contains implementations of many basic classes in `java.text` as needed by `scala-java-time` and `NumberFormat`