### PR TITLE
Tests to verify the behaviour on unknown tags

### DIFF
--- a/testSuite/shared/src/test/scala/testsuite/javalib/text/DateFormatSymbolsTest.scala
+++ b/testSuite/shared/src/test/scala/testsuite/javalib/text/DateFormatSymbolsTest.scala
@@ -663,4 +663,19 @@ class DateFormatSymbolsTest extends LocaleTestSetup {
     assertEquals(dfs, cloned)
     assertNotSame(dfs, cloned)
   }
+
+  @Test def test_bad_tag_matches_root_dfs(): Unit = {
+    val l = Locale.forLanguageTag("no_NO")
+    val dfs = DateFormatSymbols.getInstance(l)
+    standardLocalesDataDiff.foreach {
+      case (_, t @ LocaleTestItem(r, _, cldr21, _, _, _, _, _, _)) if r == root =>
+        if (Platform.executingInJVM && cldr21) {
+          test_dfs(dfs, t)
+        }
+        if (!Platform.executingInJVM && !cldr21) {
+          test_dfs(dfs, t)
+        }
+      case (_, _) =>
+    }
+  }
 }

--- a/testSuite/shared/src/test/scala/testsuite/javalib/text/DecimalFormatSymbolsTest.scala
+++ b/testSuite/shared/src/test/scala/testsuite/javalib/text/DecimalFormatSymbolsTest.scala
@@ -252,6 +252,16 @@ class DecimalFormatSymbolsTest extends LocaleTestSetup {
     assertFalse(dfs.equals(dfs2))
   }
 
+  @Test def test_bad_tag_matches_root_dfs(): Unit = {
+    val l = Locale.forLanguageTag("no_NO")
+    val dfs = DecimalFormatSymbols.getInstance(l)
+    standardLocalesData.foreach {
+      case (Locale.ROOT, symbols) =>
+        test_dfs(dfs, symbols)
+      case (_, _) =>
+    }
+  }
+
   @Ignore @Test def test_hash_code(): Unit = {
     val dfs = new DecimalFormatSymbols()
     assertEquals(dfs.hashCode, dfs.hashCode)


### PR DESCRIPTION
As suggested by @mkotsbak tests are added checking when an invalid tag is used, the `Locale` returned behaves like `ROOT`