### PR TITLE
Add support for Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ script:
 scala:
   - 2.10.6
   - 2.11.8
-  - 2.12.0-M5
+  - 2.12.0
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val commonSettings: Seq[Setting[_]] = Seq(
   version := s"0.3.0-cldr${cldrVersion.value}",
   organization := "com.github.cquiroz",
   scalaVersion := "2.11.8",
-  crossScalaVersions := Seq("2.10.4", "2.11.8", "2.12.0-RC1"),
+  crossScalaVersions := Seq("2.10.4", "2.11.8", "2.12.0"),
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings"),
   mappings in (Compile, packageBin) ~= {
     // Exclude CLDR files...

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.12")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
 
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "0.8.0")
 


### PR DESCRIPTION
This forced updating the ScalaJS plugin to 0.6.13, which most likely mean that the library will need to bump its version number.