### PR TITLE
DO NOT MERGE: Support non-latin formats

### DIFF
--- a/core/src/main/scala/java/text/DecimalFormat.scala
+++ b/core/src/main/scala/java/text/DecimalFormat.scala
@@ -73,7 +73,10 @@ class DecimalFormat(private[this] val pattern: String, private[this] var symbols
 
       val curr: JavaBigInteger = n.remainder(JavaBigInteger.TEN)
       n = n.divide(JavaBigInteger.TEN)
-      builder.append(curr.intValue)
+
+      // Assume non-latin characters 1-9 are at the same offset from the zero digit character
+      val localizedDigit = (symbols.getZeroDigit - DecimalFormatUtil.PatternCharZeroDigit) + curr.intValue
+      builder.append(localizedDigit)
       digitsWritten += 1
     }
 

--- a/testSuite/shared/src/test/scala/testsuite/javalib/text/NumberFormatTest.scala
+++ b/testSuite/shared/src/test/scala/testsuite/javalib/text/NumberFormatTest.scala
@@ -435,4 +435,31 @@ class NumberFormatTest extends LocaleTestSetup {
     assertEquals("\u22122,147,483,648", nf.format(Int.MinValue))
     assertEquals("\u22129,223,372,036,854,775,808", nf.format(Long.MinValue))
   }
+
+  @Test def test_non_latin(): Unit = {
+    // Arabic-Indic
+    if (!Platform.executingInJVM) {
+      LocaleRegistry.installLocale(hi_IN)
+    }
+
+    val locale = Locale.forLanguageTag("hi-IN")
+    assertTrue(locale != null)
+    Locale.setDefault(locale) // Override the US default
+
+    val df = NumberFormat.getInstance(locale)
+    println(s"decimal: ${df.format(1234567890.123)}")
+    assertEquals("Decimal Format", "१,२३४,५६७,८९०.१२३", df.format(1234567890.123))
+
+    val pf = NumberFormat.getPercentInstance(locale)
+    println(s"percent: ${pf.format(1234567890)}")
+    assertEquals("Percent Format", "१२३,४५६,७८९,०००%", pf.format(1234567890))
+
+    val nf = NumberFormat.getNumberInstance(locale)
+    println(s"number: ${nf.format(1234567890)}")
+    assertEquals("Number Format", "१,२३४,५६७,८९०", nf.format(1234567890))
+
+    val cf = NumberFormat.getCurrencyInstance(locale)
+    println(s"currencyFormat: ${cf.format(123456789.01)}")
+    assertEquals("Currency Format", "रू १२३,४५६,७८९.०१", cf.format(123456789.01))
+  }
 }


### PR DESCRIPTION
For some reason this breaks on the JVM, even though its not reproducible on the console:

```
eric@Erics-MacBook-Pro:~/Work/scala-java-locales$ sbt console
[info] Loading project definition from /Users/eric/Work/scala-java-locales/project
[info] Set current project to scala-java-locales (in build file:/Users/eric/Work/scala-java-locales/)
[info] Starting scala interpreter...
[info]
Welcome to Scala 2.11.8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_111).
Type in expressions for evaluation. Or try :help.

scala> import java.util.Locale
import java.util.Locale

scala> import java.text.NumberFormat
import java.text.NumberFormat

scala> val locale = Locale.forLanguageTag("hi-IN")
locale: java.util.Locale = hi_IN

scala> val decimalFormat = NumberFormat.getInstance(locale)
decimalFormat: java.text.NumberFormat = java.text.DecimalFormat@674dc

scala> decimalFormat.format(1234567890.123)
res0: String = १,२३४,५६७,८९०.१२३
```
