### PR TITLE
Scalajs 1.0.0 m3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: scala
 scala:
-  - 2.10.7
   - 2.11.12
   - 2.12.4
   - 2.13.0-M2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ jdk:
   - oraclejdk8
 env:
   - TRAVIS_NODE_VERSION="7.10.1" SCALAJS_VERSION="0.6.21"
-  - TRAVIS_NODE_VERSION="7.10.1" SCALAJS_VERSION="1.0.0-M2"
+  - TRAVIS_NODE_VERSION="7.10.1" SCALAJS_VERSION="1.0.0-M3"
   - TRAVIS_NODE_VERSION="8.9.1" SCALAJS_VERSION="0.6.21"
-  - TRAVIS_NODE_VERSION="8.9.1" SCALAJS_VERSION="1.0.0-M2"
+  - TRAVIS_NODE_VERSION="8.9.1" SCALAJS_VERSION="1.0.0-M3"
   - TRAVIS_NODE_VERSION="9.2.0" SCALAJS_VERSION="0.6.21"
-  - TRAVIS_NODE_VERSION="9.2.0" SCALAJS_VERSION="1.0.0-M2"
+  - TRAVIS_NODE_VERSION="9.2.0" SCALAJS_VERSION="1.0.0-M3"
 install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
+## 0.3.10-cldr32
+
+* Scala.js 0.6.22 and 1.0.0-M3
+
 ## 0.3.9-cldr32
 
 * Scala.js 0.6.21 and 1.0.0-M2
-* Scala versions 2.10.7, 2.11.12, 2.12.2 and 2.13.0-M2
+* Scala versions 2.10.7, 2.11.12, 2.12.4 and 2.13.0-M2
 * Updated to cldr32
 
 ## 0.3.8-cldr31

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Simply add the following line to your sbt settings:
 
 ```scala
-libraryDependencies += "com.github.cquiroz" %%% "scala-java-locales" % "0.3.9-cldr32"
+libraryDependencies += "com.github.cquiroz" %%% "scala-java-locales" % "0.3.10-cldr32"
 ```
 
 If you have a `crossProject`, the setting must be used only in the JS part:
@@ -20,11 +20,11 @@ If you have a `crossProject`, the setting must be used only in the JS part:
 lazy val myCross = crossProject.
   ...
   .jsSettings(
-    libraryDependencies += "com.github.cquiroz" %%% "scala-java-locales" % "0.3.9-cldr32"
+    libraryDependencies += "com.github.cquiroz" %%% "scala-java-locales" % "0.3.10-cldr32"
   )
 ```
 
-**Requirement**: you must use a host JDK8 to *build* your project, i.e., to
+**Requirement**: you must use a host JDK8 to _build_ your project, i.e., to
 launch sbt. `scala-java-locales` does not work on earlier JDKs.
 
 ## Work in Progress / linking errors
@@ -48,7 +48,7 @@ LocaleRegistry.installLocale(fi_FI)
 val dfs = DecimalFormatSymbols.getInstance(Locale.forLanguageTag("fi_FI"))
 ```
 
-***Note:*** that calls to `Locale.forLanguageTag("fi_FI")` will succeed regardless of the installation due to the requirements on the `Locale` API
+**_Note:_** that calls to `Locale.forLanguageTag("fi_FI")` will succeed regardless of the installation due to the requirements on the `Locale` API
 
 ## Default Locale
 
@@ -91,12 +91,13 @@ A very simple `Scala.js` project is available at [scalajs-locales-demo](https://
 `scala-java-locales` uses [Semantic Versioning](http://semver.org/) and includes the CLDR version used as a build tag, e.g.:
 
 ```
-0.3.9-cldr32 // Version 0.3.9 with CLDR version 32
+0.3.10-cldr32 // Version 0.3.10 with CLDR version 32
 ```
 
 ## Publishing
 
-on 0.6.21
+on 0.6.22
+
 ```
 sbt
 clean
@@ -107,9 +108,10 @@ sonatyeRelease
 
 Important: Remember to clean between different scala.js versions
 
-on 1.0.0-M2
+on 1.0.0-M3
+
 ```
-SCALAJS_VERSION=1.0.0-M2 sbt
+SCALAJS_VERSION=1.0.0-M3 sbt
 clean
 +publishSigned
 sonatyeRelease

--- a/build.sbt
+++ b/build.sbt
@@ -8,10 +8,16 @@ lazy val downloadFromZip: TaskKey[Unit] =
 
 val commonSettings: Seq[Setting[_]] = Seq(
   cldrVersion := "32",
-  version := s"0.3.9-cldr${cldrVersion.value}",
+  version := s"0.3.10-cldr${cldrVersion.value}",
   organization := "io.github.cquiroz",
   scalaVersion := "2.12.4",
-  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.4", "2.13.0-M2"),
+  crossScalaVersions := {
+    if (scalaJSVersion.startsWith("0.6")) {
+      Seq("2.10.7", "2.11.12", "2.12.4", "2.13.0-M2")
+    } else {
+      Seq("2.11.12", "2.12.4", "2.13.0-M2")
+    }
+  },
   scalacOptions ++= Seq("-deprecation", "-feature"),
   scalacOptions := {
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/testSuite/js/src/test/scala/testsuite/utils/Platform.scala
+++ b/testSuite/js/src/test/scala/testsuite/utils/Platform.scala
@@ -19,9 +19,4 @@ object Platform {
 
   final val executingInJVMOnJDK7OrLower = false
 
-  // Members that are only accessible from testSuite/js
-  // (i.e. do no link on the JVM).
-
-  def areTypedArraysSupported: Boolean =
-    runtime.Bits.areTypedArraysSupported
 }


### PR DESCRIPTION
Add support to build on `Scala.js 1.0.0-M3`. Unfortunately it means we have to disable tests on scala 2.10