### PR TITLE
String/Character implicits playground

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,8 @@ lazy val scalajs_locales: Project = project
   // don't include scala-native by default
   .aggregate(core.js,
              core.jvm,
+             implicits.js,
+             implicits.jvm,
              testSuite.js,
              testSuite.jvm,
              localesFullDb.js,
@@ -100,6 +102,23 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
   .jvmSettings(
     skip.in(publish) := scalaJSVersion06
   )
+
+lazy val implicits = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Full)
+  .settings(commonSettings: _*)
+  .settings(
+    publish := {},
+    publishLocal := {},
+    publishArtifact := false,
+    name := "scala-java-locales-implicits"
+//    scalacOptions ~= (_.filterNot(
+//      Set(
+//        "-deprecation",
+//        "-Xfatal-warnings"
+//      )
+//    ))
+  )
+  .jsConfigure(_.dependsOn(core.js))
 
 lazy val localesFullCurrenciesDb = crossProject(JVMPlatform, JSPlatform)
   .settings(commonSettings: _*)
@@ -171,6 +190,7 @@ lazy val testSuite = crossProject(JVMPlatform, JSPlatform)
       )
     ))
   )
+  .dependsOn(implicits)
   .jsSettings(parallelExecution in Test := false,
               name := "scala-java-locales testSuite on JS",
               scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)))

--- a/core/shared/src/main/scala/java/util/Locale.scala
+++ b/core/shared/src/main/scala/java/util/Locale.scala
@@ -467,7 +467,7 @@ class Locale private[util] (
       _extensions
   }
 
-  private def updateSpecialLanguages(l: String) =
+  private def updateSpecialLanguages(l: String): String =
     l match {
       case "iw" => "he"
       case "ji" => "yi"
@@ -475,7 +475,7 @@ class Locale private[util] (
       case _    => l
     }
 
-  private def translateSpecialLanguages(l: String) =
+  private def translateSpecialLanguages(l: String): String =
     l match {
       case "he" => "iw"
       case "yi" => "ji"

--- a/implicits/js/src/main/scala/locales/ImplicitsPlatform.scala
+++ b/implicits/js/src/main/scala/locales/ImplicitsPlatform.scala
@@ -1,0 +1,28 @@
+package locales
+
+import java.util.Locale
+
+object ImplicitsPlatform {
+  final class RichString(val str: String) extends AnyVal {
+    def toUpperCase(locale: Locale): String = ???
+    def toLowerCase(locale: Locale): String = ???
+  }
+
+  // final class RichCharacterObj(val obj: java.lang.Character.type) extends AnyVal {
+  //   def toTitleCase(ch: Char): String = ???
+  //   def toTitleCase(codePoint: Int): String = ???
+    
+  //   def toLowerCase(ch: Char): String = ???
+  //   def toLowerCase(codePoint: Int): String = ???
+
+  //   def toUpperCase(ch: Char): String = ???
+  //   def toUpperCase(codePoint: Int): String = ???
+  // }
+}
+
+/** JS Platform-specific implementations for Implicit companion object */
+trait ImplicitsPlatform {
+  import ImplicitsPlatform._
+  // implicit def toRichCharacterObj(obj: java.lang.Character.type): RichCharacterObj = new RichCharacterObj(obj)
+  implicit def RichString(str: String): RichString = new RichString(str)
+}

--- a/implicits/jvm/src/main/scala/locales/ImplicitsPlatform.scala
+++ b/implicits/jvm/src/main/scala/locales/ImplicitsPlatform.scala
@@ -1,0 +1,6 @@
+package locales
+
+/** JVM Platform-specific implementations for Implicit companion object */
+trait ImplicitsPlatform {
+
+}

--- a/implicits/shared/src/main/scala/locales/Implicits.scala
+++ b/implicits/shared/src/main/scala/locales/Implicits.scala
@@ -1,0 +1,18 @@
+package locales
+
+object Implicits extends Implicits {
+
+  /** 
+   * Used to swallow unused warnings. 
+   * 
+   * e.g. 
+   * import locales.Implicits._
+   * ...
+   * void(foo) 
+   **/
+  @inline def void(as: Any*): Unit = (as, ())._2
+}
+
+trait Implicits extends ImplicitsPlatform {
+
+}

--- a/testSuite/shared/src/test/scala/testsuite/javalib/lang/CharacterTest.scala
+++ b/testSuite/shared/src/test/scala/testsuite/javalib/lang/CharacterTest.scala
@@ -1,0 +1,12 @@
+package testsuite.javalib.lang
+
+import locales.Implicits._
+
+class CharacterTest extends munit.FunSuite {
+  val hellowWorldLower: String = "helloworld"
+  val helloWorldUpper = "HELLOWORLD"
+
+  // Used to swallow unused imports warning on JVM platform
+  void(hellowWorldLower)
+
+}

--- a/testSuite/shared/src/test/scala/testsuite/javalib/lang/StringTest.scala
+++ b/testSuite/shared/src/test/scala/testsuite/javalib/lang/StringTest.scala
@@ -1,0 +1,22 @@
+package testsuite.javalib.lang
+
+import java.util.Locale
+import locales.Implicits._
+
+class StringTest extends munit.FunSuite {
+  val hellowWorldLower: String = "helloworld"
+  val helloWorldUpper = "HELLOWORLD"
+
+  // Used to swallow unused imports warning on JVM platform
+  void(hellowWorldLower)
+
+  test("toUpperCase(Locale)") {
+    assertEquals("\u0049", "\u0069".toUpperCase(Locale.ENGLISH))
+    assertEquals("\u0130", "\u0069".toUpperCase(new Locale("tr", "")))
+  }
+
+  test("toLowerCase(Locale)") {
+    assertEquals("\u0069", "\u0049".toLowerCase(Locale.ENGLISH))
+    assertEquals("\u0069", "\u0130".toUpperCase(new Locale("tr", "")))
+  }
+}


### PR DESCRIPTION
Playground for https://github.com/cquiroz/scala-java-locales/issues/197

The separate package (e.g. `implicits` - is there a better name for this?) is required since `core` code isn't included in the jvm artifact, and we need the noop-import.

Questions:
- Does `implicits` make sense, should it be some other `compat` style name?
- Does adding the `void` param also make sense?