### PR TITLE
Fast-path string-to-cstring conversion

### DIFF
--- a/core/native/src/main/scala-2/java/text/Normalizer.scala
+++ b/core/native/src/main/scala-2/java/text/Normalizer.scala
@@ -1,32 +1,9 @@
 package java.text
 
-import java.nio.CharBuffer
-import java.nio.charset.Charset
-import scala.scalanative.libc.stdlib
-import scala.scalanative.unsafe._
-
 object Normalizer {
 
   def normalize(src: CharSequence, form: Form): String =
-    if (src == null || form == null)
-      throw new NullPointerException
-    else
-      Zone { implicit z =>
-        import Form._
-        import utf8proc._
-
-        val cstr = form match {
-          case NFC  => utf8proc_NFC(charSeqToCString(src))
-          case NFD  => utf8proc_NFD(charSeqToCString(src))
-          case NFKC => utf8proc_NFKC(charSeqToCString(src))
-          case NFKD => utf8proc_NFKD(charSeqToCString(src))
-          case _    => throw new IllegalArgumentException // should never happen
-        }
-
-        val normalized = fromCString(cstr) // TODO can be further optimized
-        stdlib.free(cstr)
-        normalized
-      }
+    NormalizerImpl.normalize(src, form)
 
   def isNormalized(src: CharSequence, form: Form): Boolean =
     normalize(src, form).contentEquals(src)
@@ -40,35 +17,4 @@ object Normalizer {
     final val NFKD: Form = new Form("NFKD", 3)
   }
 
-  private def charSeqToCString(cs: CharSequence)(implicit z: Zone): CString = cs match {
-    case str: String => toCString(str)
-    case str         =>
-      import scalanative.unsigned._
-
-      val encoder = Charset.defaultCharset().newEncoder()
-      val cb      = CharBuffer.wrap(str)
-      val bb      = encoder.encode(cb)
-
-      val n    = bb.limit()
-      val cstr = z.alloc((n + 1).toULong)
-
-      var i = 0
-      while (i < n) {
-        !(cstr + i.toLong) = bb.get(i)
-        i += 1
-      }
-      !(cstr + i.toLong) = 0.toByte
-
-      cstr
-  }
-
-}
-
-@link("utf8proc")
-@extern
-private object utf8proc {
-  def utf8proc_NFD(str: CString): CString  = extern
-  def utf8proc_NFC(str: CString): CString  = extern
-  def utf8proc_NFKD(str: CString): CString = extern
-  def utf8proc_NFKC(str: CString): CString = extern
 }

--- a/core/native/src/main/scala-3/java/text/Normalizer.scala
+++ b/core/native/src/main/scala-3/java/text/Normalizer.scala
@@ -16,10 +16,10 @@ object Normalizer {
         import utf8proc._
 
         val cstr = form match {
-          case NFC  => utf8proc_NFC(toCString(src))
-          case NFD  => utf8proc_NFD(toCString(src))
-          case NFKC => utf8proc_NFKC(toCString(src))
-          case NFKD => utf8proc_NFKD(toCString(src))
+          case NFC  => utf8proc_NFC(charSeqToCString(src))
+          case NFD  => utf8proc_NFD(charSeqToCString(src))
+          case NFKC => utf8proc_NFKC(charSeqToCString(src))
+          case NFKD => utf8proc_NFKD(charSeqToCString(src))
         }
 
         val normalized = fromCString(cstr) // TODO can be further optimized
@@ -33,24 +33,26 @@ object Normalizer {
   enum Form extends java.lang.Enum[Form]:
     case NFC, NFD, NFKC, NFKD
 
-  private def toCString(str: CharSequence)(implicit z: Zone): CString = {
-    import scalanative.unsigned._
+  private def charSeqToCString(cs: CharSequence)(implicit z: Zone): CString = cs match {
+    case str: String => toCString(str)
+    case str         =>
+      import scalanative.unsigned._
 
-    val encoder = Charset.defaultCharset().newEncoder()
-    val cb      = CharBuffer.wrap(str)
-    val bb      = encoder.encode(cb)
+      val encoder = Charset.defaultCharset().newEncoder()
+      val cb      = CharBuffer.wrap(str)
+      val bb      = encoder.encode(cb)
 
-    val n    = bb.limit()
-    val cstr = z.alloc((n + 1).toULong)
+      val n    = bb.limit()
+      val cstr = z.alloc((n + 1).toULong)
 
-    var i = 0
-    while (i < n) {
-      !(cstr + i.toLong) = bb.get(i)
-      i += 1
-    }
-    !(cstr + i.toLong) = 0.toByte
+      var i = 0
+      while (i < n) {
+        !(cstr + i.toLong) = bb.get(i)
+        i += 1
+      }
+      !(cstr + i.toLong) = 0.toByte
 
-    cstr
+      cstr
   }
 
 }

--- a/core/native/src/main/scala-3/java/text/Normalizer.scala
+++ b/core/native/src/main/scala-3/java/text/Normalizer.scala
@@ -1,31 +1,9 @@
 package java.text
 
-import java.nio.CharBuffer
-import java.nio.charset.Charset
-import scala.scalanative.libc.stdlib
-import scala.scalanative.unsafe._
-
 object Normalizer {
 
   def normalize(src: CharSequence, form: Form): String =
-    if (src == null || form == null)
-      throw new NullPointerException
-    else
-      Zone { implicit z =>
-        import Form._
-        import utf8proc._
-
-        val cstr = form match {
-          case NFC  => utf8proc_NFC(charSeqToCString(src))
-          case NFD  => utf8proc_NFD(charSeqToCString(src))
-          case NFKC => utf8proc_NFKC(charSeqToCString(src))
-          case NFKD => utf8proc_NFKD(charSeqToCString(src))
-        }
-
-        val normalized = fromCString(cstr) // TODO can be further optimized
-        stdlib.free(cstr)
-        normalized
-      }
+    NormalizerImpl.normalize(src, form)
 
   def isNormalized(src: CharSequence, form: Form): Boolean =
     normalize(src, form).contentEquals(src)
@@ -33,35 +11,4 @@ object Normalizer {
   enum Form extends java.lang.Enum[Form]:
     case NFC, NFD, NFKC, NFKD
 
-  private def charSeqToCString(cs: CharSequence)(implicit z: Zone): CString = cs match {
-    case str: String => toCString(str)
-    case str         =>
-      import scalanative.unsigned._
-
-      val encoder = Charset.defaultCharset().newEncoder()
-      val cb      = CharBuffer.wrap(str)
-      val bb      = encoder.encode(cb)
-
-      val n    = bb.limit()
-      val cstr = z.alloc((n + 1).toULong)
-
-      var i = 0
-      while (i < n) {
-        !(cstr + i.toLong) = bb.get(i)
-        i += 1
-      }
-      !(cstr + i.toLong) = 0.toByte
-
-      cstr
-  }
-
-}
-
-@link("utf8proc")
-@extern
-private object utf8proc {
-  def utf8proc_NFD(str: CString): CString  = extern
-  def utf8proc_NFC(str: CString): CString  = extern
-  def utf8proc_NFKD(str: CString): CString = extern
-  def utf8proc_NFKC(str: CString): CString = extern
 }

--- a/core/native/src/main/scala/locales/NormalizerImpl.scala
+++ b/core/native/src/main/scala/locales/NormalizerImpl.scala
@@ -1,0 +1,63 @@
+package java.text
+
+import java.nio.CharBuffer
+import java.nio.charset.Charset
+import scala.scalanative.libc.stdlib
+import scala.scalanative.unsafe._
+
+import Normalizer._
+
+private object NormalizerImpl {
+
+  def normalize(src: CharSequence, form: Form): String =
+    if (src == null || form == null)
+      throw new NullPointerException
+    else
+      Zone { implicit z =>
+        import Form._
+        import utf8proc._
+
+        val cstr = form match {
+          case NFC  => utf8proc_NFC(charSeqToCString(src))
+          case NFD  => utf8proc_NFD(charSeqToCString(src))
+          case NFKC => utf8proc_NFKC(charSeqToCString(src))
+          case NFKD => utf8proc_NFKD(charSeqToCString(src))
+        }
+
+        val normalized = fromCString(cstr) // TODO can be further optimized
+        stdlib.free(cstr)
+        normalized
+      }
+
+  private def charSeqToCString(cs: CharSequence)(implicit z: Zone): CString = cs match {
+    case str: String => toCString(str)
+    case str         =>
+      import scalanative.unsigned._
+
+      val encoder = Charset.defaultCharset().newEncoder()
+      val cb      = CharBuffer.wrap(str)
+      val bb      = encoder.encode(cb)
+
+      val n    = bb.limit()
+      val cstr = z.alloc((n + 1).toULong)
+
+      var i = 0
+      while (i < n) {
+        !(cstr + i.toLong) = bb.get(i)
+        i += 1
+      }
+      !(cstr + i.toLong) = 0.toByte
+
+      cstr
+  }
+
+}
+
+@link("utf8proc")
+@extern
+private object utf8proc {
+  def utf8proc_NFD(str: CString): CString  = extern
+  def utf8proc_NFC(str: CString): CString  = extern
+  def utf8proc_NFKD(str: CString): CString = extern
+  def utf8proc_NFKC(str: CString): CString = extern
+}


### PR DESCRIPTION
`String` can be converted to a `CString` more easily than a generic `CharSequence`, so we should prefer to do that when possible.